### PR TITLE
refactor: update Java version and compiler settings to 21 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
     <name>dinseiworld</name>
     <description>dinseiworld</description>
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <vaadin.version>24.5.3</vaadin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <lombok.version>1.18.30</lombok.version>
     </properties>
@@ -92,8 +92,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This pull request updates the Java version used in the `pom.xml` file from 17 to 21, ensuring compatibility with the latest features and improvements in Java. The changes affect both the project properties and the Maven compiler plugin configuration.

Java version update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L18-R21): Updated `java.version`, `maven.compiler.source`, and `maven.compiler.target` properties from 17 to 21.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L95-R96): Modified the Maven compiler plugin configuration to use `source` and `target` version 21 instead of 17.